### PR TITLE
fix: B46 counts allowlist/paired ingress (consistency with trifecta input leg)

### DIFF
--- a/clawseccheck/checks.py
+++ b/clawseccheck/checks.py
@@ -5623,8 +5623,8 @@ def check_multiagent_exposure(ctx: Context) -> Finding:
 
     WARN    — multi-agent topology with no approval gate and either:
               (a) global trifecta fully active, or
-              (b) open ingress + elevated tool sender scope despite missing explicit
-                  sensitive-data leg.
+              (b) external (non-owner) ingress + elevated tool sender scope despite
+                  missing explicit sensitive-data leg.
     PASS    — multi-agent topology present but none of the warn conditions apply, or a gate
               exists.
     UNKNOWN — no multi-agent topology (single agent; A1 already covers that case).
@@ -5637,19 +5637,23 @@ def check_multiagent_exposure(ctx: Context) -> Finding:
             "trifecta exposure does not apply (single-agent trifecta is covered by A1).",
             "—",
         )
-    open_ch = _open_channels(cfg)
+    # Untrusted ingress = open/allowlist/paired (authenticated sender != trusted
+    # content), matching the trifecta input leg computed in _trifecta_legs(); an
+    # allowlist channel is ingress here too. NB: B55's FAIL gate deliberately uses
+    # _open_channels (open-only) instead — see check_fs_write_exposure.
+    ext_ch = _external_input_channels(cfg)
     legs = _trifecta_legs(ctx)
     if not all(legs.values()):
-        if open_ch and bool(dig(cfg, "tools.elevated.allowFrom")) and not _has_approval_gate(cfg):
+        if ext_ch and bool(dig(cfg, "tools.elevated.allowFrom")) and not _has_approval_gate(cfg):
             return _finding(
                 "B46", WARN,
-                "Multiple agents/subagents can be spawned, open ingress exists, and "
-                "elevated tools are sender-restricted (not tightly approval-gated), "
-                "so a multi-agent topology can still amplify an injection via elevated "
-                "actions.",
+                "Multiple agents/subagents can be spawned, external (non-owner) ingress "
+                "exists (open/allowlist/paired), and elevated tools are sender-restricted "
+                "(not tightly approval-gated), so a multi-agent topology can still amplify "
+                "an injection via elevated actions.",
                 "Reduce sender surface for elevated tooling and/or set an approval "
                 "gate (tools.exec.mode='ask'/'allowlist'). Do not rely on "
-                "coarse allowFrom for elevated tooling with open channels.",
+                "coarse allowFrom for elevated tooling with externally-reachable channels.",
             )
         return _finding(
             "B46", PASS,
@@ -5924,6 +5928,13 @@ def check_fs_write_exposure(ctx: Context) -> Finding:
         isinstance(allow_from, list) and bool(allow_from) and "*" not in allow_from
     )
     wildcard = allow_from == "*" or (isinstance(allow_from, list) and "*" in allow_from)
+    # DELIBERATE: _open_channels (open-only), NOT _external_input_channels. This feeds the
+    # FAIL gate below; a hard FAIL ("arbitrary writes reachable by untrusted senders")
+    # requires proven-broad reach — a wildcard sender or a truly-open/public channel. An
+    # allowlist/paired channel carries untrusted *content* but is not broad reach, so it
+    # stays the WARN fallback (locked by test_ungated_write_without_broad_reach_warns).
+    # Widening this to _external_input_channels would flip allowlist configs WARN->FAIL,
+    # a §5 false-positive FAIL. B46 uses the broader helper because it is WARN-capped.
     open_ch = _open_channels(cfg)
 
     # Approval via tools.exec affects exec/shell-like actions; it is not a

--- a/tests/test_b46.py
+++ b/tests/test_b46.py
@@ -82,6 +82,52 @@ def test_b46_elevated_only_triggers_warn_for_open_channel():
     assert r.status == "WARN"
 
 
+# ---- partial-trifecta branch counts allowlist/paired ingress, not just open (B-057) ----
+# An allowlist/paired channel is untrusted ingress (authenticated sender != trusted
+# content), consistent with the trifecta input leg in _trifecta_legs(). This branch
+# previously used _open_channels and silently PASSed an allowlist+elevated+subagents config.
+def test_b46_allowlist_channel_with_elevated_warns():
+    cfg = {
+        "channels": {"tg": {"dmPolicy": "allowlist"}},  # untrusted ingress, NOT open
+        "tools": {"allow": ["send_email"], "elevated": {"allowFrom": ["owner-111"]}},
+        "agents": {"subagents": {"maxConcurrent": 4}},
+    }
+    r = check_multiagent_exposure(_ctx(cfg))
+    assert r.status == "WARN"
+    assert r.scored is True
+
+
+def test_b46_paired_channel_with_elevated_warns():
+    cfg = {
+        "channels": {"tg": {"dmPolicy": "paired"}},  # paired is still external ingress
+        "tools": {"allow": ["send_email"], "elevated": {"allowFrom": ["owner-111"]}},
+        "agents": {"subagents": {"maxConcurrent": 4}},
+    }
+    assert check_multiagent_exposure(_ctx(cfg)).status == "WARN"
+
+
+# clean control: the partial branch only fires WITH elevated sender scope — an allowlist
+# channel + subagents but no elevated.allowFrom must stay PASS (the fix is not over-wide).
+def test_b46_allowlist_channel_without_elevated_passes():
+    cfg = {
+        "channels": {"tg": {"dmPolicy": "allowlist"}},
+        "tools": {"allow": ["send_email"]},  # no elevated.allowFrom
+        "agents": {"subagents": {"maxConcurrent": 4}},
+    }
+    assert check_multiagent_exposure(_ctx(cfg)).status == "PASS"
+
+
+# boundary: an owner-only channel is NOT external ingress, so the branch must not fire
+# even with elevated sender scope (proves "external" means non-owner, not "any channel").
+def test_b46_owner_only_channel_with_elevated_passes():
+    cfg = {
+        "channels": {"tg": {"dmPolicy": "owner"}},  # excluded from untrusted ingress
+        "tools": {"allow": ["send_email"], "elevated": {"allowFrom": ["owner-111"]}},
+        "agents": {"subagents": {"maxConcurrent": 4}},
+    }
+    assert check_multiagent_exposure(_ctx(cfg)).status == "PASS"
+
+
 # ---- B46 is capped at WARN: it must NEVER FAIL (cannot add new FAILs on real configs) ----
 def test_b46_never_fails():
     for cfg in (

--- a/tests/test_b55.py
+++ b/tests/test_b55.py
@@ -87,6 +87,30 @@ def test_ungated_write_without_broad_reach_warns(tmp_path):
     assert any("apply_patch" in e for e in f.evidence)
 
 
+# B-057 invariant: the FAIL gate uses _open_channels (open-only) BY DESIGN. An allowlist
+# or paired channel is untrusted *content* but not proven-broad reach, so a write tool
+# behind one stays WARN — never FAIL. Widening the gate to _external_input_channels would
+# flip these to FAIL: a §5 false-positive. These lock that boundary explicitly.
+def test_b55_allowlist_channel_does_not_escalate_to_fail(tmp_path):
+    home = _write_config(
+        tmp_path,
+        '{"channels": {"telegram": {"dmPolicy": "allowlist"}},'
+        ' "tools": {"allow": ["fs_write"]}}',
+    )
+    f = _b55(home)
+    assert f.status == WARN, f.detail
+    assert f.status != FAIL
+
+
+def test_b55_paired_channel_does_not_escalate_to_fail(tmp_path):
+    home = _write_config(
+        tmp_path,
+        '{"channels": {"telegram": {"dmPolicy": "paired"}},'
+        ' "tools": {"allow": ["fs_write"]}}',
+    )
+    assert _b55(home).status == WARN
+
+
 # --------------------------------------------------------------------------- UNKNOWN
 def test_no_tool_allowlist_is_unknown(tmp_path):
     home = _write_config(tmp_path, '{"gateway": {"bind": "127.0.0.1:8080"}}')


### PR DESCRIPTION
## Summary
Follow-up from the B-041 capability-graph audit. B46 (`check_multiagent_exposure`) partial-trifecta WARN branch used `_open_channels` (open-only) while the adjacent trifecta input leg (`_trifecta_legs`) uses `_external_input_channels` (open/allowlist/paired). An allowlist channel therefore counted as untrusted input when deciding full-vs-partial, but **not** as ingress inside the partial branch — so an `allowlist + elevated.allowFrom + subagents` config silently PASSed. Now both reads agree (authenticated sender ≠ trusted content).

B46 is **WARN-capped**, so this introduces **no new FAIL** on real configs (§5).

## Why B55 is NOT changed (the audit's other half)
The B-041 note hypothesized B55 (`check_fs_write_exposure`) was the *same* misuse. It is not. B55's `_open_channels` sits on the **FAIL** gate; a hard FAIL needs proven-broad reach (a wildcard sender or a truly-open channel). An allowlist/paired channel stays WARN. Converting it would flip allowlist configs WARN→FAIL — a §5 false-positive — and break the existing `test_ungated_write_without_broad_reach_warns`. The deliberate choice is now documented in-code and locked with explicit regression tests so a future "consistency" refactor cannot reintroduce it.

## Grounding (zero false-positive discipline)
- Real `~/.openclaw`: B46 and B55 both **UNKNOWN** → zero regression on the real fleet.
- ClawRange: **no golden drift** (44 scenarios) → no modeled fleet config flips grade.

## Tests
- **B46** — allowlist/paired + elevated + subagents → **WARN**; allowlist-without-elevated and owner-only → **PASS** (clean controls, proving the fix is not over-wide); no-subagents → UNKNOWN (existing).
- **B55** — allowlist/paired write tool stays **WARN, never FAIL** (§5 invariant lock).

## Verification
- `python3 -m pytest -q` — **2463 passed, 0 skipped**
- `ruff check .` — clean
- ClawRange `range.py` — **RANGE GREEN (44)**; `hunt.py --all` — HUNT / FNEG / FUZZ / METAMORPHIC all clean
