### PR TITLE
ci: group GitHub Actions dependabot bumps into one weekly PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,10 @@ updates:
       - "ci"
     commit-message:
       prefix: "ci"
+    # Bundle all GitHub Actions bumps into a single weekly PR instead of one
+    # PR per action, so they no longer pile up and conflict against each other
+    # in the shared workflow files. Grouped bumps still keep the SHA-pin (E-028).
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Add a `groups:` block to `.github/dependabot.yml` so all GitHub Actions version bumps arrive as **one** weekly PR instead of one PR per action.

## Why

Four separate Dependabot PRs (#10, #11, #13, #14) piled up and started conflicting against each other in the shared workflow files (adjacent `uses:` lines produce overlapping context hunks). Grouping removes both the per-PR toil and the self-conflicts.

- Still SHA-pinned — grouped bumps keep the `@<sha>  # vX` format (E-028).
- Actions-only scope unchanged (Python stays zero-dep, `fixtures/requirements.txt` stays untouched).