### PR TITLE
ci: correct dependency-review-action pin comment to v5.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v4
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0
         with:
           fail-on-severity: high
 


### PR DESCRIPTION
Dependabot #14 correctly bumped the `dependency-review-action` SHA to v5.0.0 (`2031cfc` → `a1d282b`) but left the inline version comment as `# v4`. Correct it to `# v5.0.0` so the SHA-pin annotation is honest for audit (E-028).

Comment-only change — no behavior change.