### PR TITLE
ci: supply-chain hardening — checksum-verified gitleaks, security docs under markdownlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,14 @@ jobs:
       - name: Install markdownlint-cli
         run: npm install -g markdownlint-cli@0.44.0
       - name: Lint Markdown
+        # CHANGELOG.md stays ignored (high-churn release log, repeated structures).
+        # SKILL.md/SECURITY.md/SECURITY_MODEL.md are linted like everything else —
+        # SKILL.md relaxes two formatting-only rules via an inline
+        # markdownlint-disable comment instead of a whole-file ignore.
         run: |
           markdownlint '**/*.md' \
             --ignore node_modules \
             --ignore CHANGELOG.md \
-            --ignore SKILL.md \
-            --ignore SECURITY.md \
-            --ignore SECURITY_MODEL.md \
             --config .markdownlint.jsonc
 
   # -- L3: dependency review (PRs only) ----------------------------------------
@@ -77,10 +78,19 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install gitleaks
+        # Pinned version AND pinned SHA-256: the tarball is fetched from a GitHub
+        # release at runtime, so verify its digest before anything from it can run
+        # (same supply-chain discipline as the SHA-pinned actions). Bump SHA256
+        # together with VERSION — it's the linux_x64 line of the release's
+        # gitleaks_<VERSION>_checksums.txt.
         run: |
           VERSION="8.27.2"
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
-            | tar -xz -C /usr/local/bin gitleaks
+          SHA256="141c3b2dede46d8b3a53b47116da756bd223decc0374797559a6b50ecba5590c"
+          curl -sSfL -o gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz"
+          echo "${SHA256}  gitleaks.tar.gz" | sha256sum --check --strict
+          tar -xzf gitleaks.tar.gz -C /usr/local/bin gitleaks
+          rm gitleaks.tar.gz
       - name: Scan for secrets (gitleaks)
         run: gitleaks detect --source=. --config=.gitleaks.toml --redact --no-banner
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,12 +47,14 @@ data-handling/redaction discipline, tamper-evident audit trail, and the forward-
 policy for any future fix/apply mode, see [`SECURITY_MODEL.md`](SECURITY_MODEL.md).
 
 In-scope issues include:
+
 - Logic bugs that produce false PASS results for genuinely unsafe configs.
 - Output channels that could be exploited for prompt injection (e.g. `--prompts`).
 - Any code path that reads, writes, or executes more than the documented scope.
 - Dependency or supply-chain issues in the publish workflow.
 
 Out of scope:
+
 - Vulnerabilities in OpenClaw itself (report those to the OpenClaw project).
 - Issues only reproducible by a malicious local user who already has filesystem access.
 

--- a/SECURITY_MODEL.md
+++ b/SECURITY_MODEL.md
@@ -57,7 +57,7 @@ introduced:
 
 ## Trust boundaries
 
-```
+```text
 [ User's filesystem ]
         |  read-only
         v
@@ -277,6 +277,7 @@ A release must pass local validation before merge/tag:
 - targeted checks for the changed modules.
 
 Also verify that release documentation is synchronized:
+
 - `README.md`
 - `CHANGELOG.md`
 - `SECURITY.md`

--- a/SKILL.md
+++ b/SKILL.md
@@ -6,6 +6,11 @@ license: MIT
 metadata: {"openclaw":{"emoji":"🔍","os":["darwin","linux","win32"],"user-invocable":true},"display_name":{"en":"ClawSecCheck — OpenClaw Security Self-Audit"},"display_description":{"en":"Free, local security self-audit for your own OpenClaw agent. Reads your OpenClaw config, bootstrap files, log files, agent session logs, and installed skills — read-only against your OpenClaw setup, plus a bounded host-security scan; writes only its own local report/history (removable with --purge). Scores your setup (A–F) and reports the most urgent holes — it never changes your OpenClaw setup. No API key, no data leaves your machine. Use it when you want to check or audit your OpenClaw agent's security, find prompt-injection or misconfiguration risks, or see your A–F security score."},"tags":{"en":["security","openclaw","ai-agent","audit","prompt-injection","llm-security","self-audit","sarif"]}}
 ---
 
+<!-- markdownlint-disable MD040 MD032 -->
+<!-- Formatting-only rules (fence language tags, blanks around lists) are relaxed
+     for this agent-facing manifest, whose fence/list layout is deliberate.
+     All content rules still apply. -->
+
 # ClawSecCheck — OpenClaw Security Self-Audit
 
 ## When to use this skill
@@ -266,7 +271,7 @@ rest on demand. The number, the phrase, or a tap all select an item; free phrasi
 | Choice | Flag(s) | Notes |
 |--------|---------|-------|
 | 1 Check everything ("check" / "go") | `--full` (+ auto capability self-report, see Step 2) | Read-only audit **+** capability self-report (resolves B43/B44 inline instead of leaving them UNKNOWN for a separate "deeper" step — F-043) **+** self-test scenario generation (canary/dryrun/redteam — generates injection scenarios; it does not itself run a behavioral verdict) **+** MCP vet, in one go. The actual ⚡ live behavioral test (VULNERABLE vs RESISTANT) is a separate, opt-in step offered after the dashboard (Section 6, item a) — not part of item 1. |
-| 2 Check before install | `--vet <path>` (autodetects skill · plugin · MCP spec; `--vet-skill` / `--vet-plugin` force an engine) · `--vet-mcp [name]` (configured MCP) · `--vet-source <slug|url>` (before anything is even downloaded) | Supply-chain check on something you're about to trust. See vet flow in Step 5. |
+| 2 Check before install | `--vet <path>` (autodetects skill · plugin · MCP spec; `--vet-skill` / `--vet-plugin` force an engine) · `--vet-mcp [name]` (configured MCP) · `--vet-source <slug\|url>` (before anything is even downloaded) | Supply-chain check on something you're about to trust. See vet flow in Step 5. |
 | 3 Report & history | default report · `--save <path>` · `--trend` · `--badge <path>` | Show or save the last result, the score trend, or a shareable badge. |
 | 4 Menu | `--functions` (Screen 12 — the full palette) | Saying "menu" / "functions" / "more" expands the complete capability list — run `python3 {baseDir}/audit.py --functions` (or present its output). Every capability appears as a speakable prompt grounded to its real flag (verify, what-changed, html, sarif, percentile, risk-paths, the vet family, the ⚡ live tests, …), so there's no wall of raw flags. (`--menu` itself renders *this* Welcome screen; the palette is one level deeper.) |
 | "private" modifier | Add `--no-history` to any mode | "1 private" = Check everything + `--no-history`. Nothing written to `~/.clawseccheck/`. |
@@ -775,7 +780,7 @@ Use this to map what the user says to the right command:
 | "fix", "how do I fix", "what should I do" | out of scope — reports only; explain, don't generate fixes |
 | "vet", "scan this skill", "is this safe to install", "check before I install" | `--vet <path>` — type autodetected; `--vet-skill <path>` forces the skill engine (add `--json` or `--sarif PATH` for machine-readable / CI output) |
 | "vet this plugin", "is this plugin safe" | `--vet-plugin <path>` (plugin root or `openclaw.plugin.json`; `--vet <path>` autodetects too) |
-| "is this safe to download", "check this link / package before I fetch it" | `--vet-source <slug|url|pkg>` — zero network, identity only; then quarantine + `--vet` the fetched copy |
+| "is this safe to download", "check this link / package before I fetch it" | `--vet-source <slug\|url\|pkg>` — zero network, identity only; then quarantine + `--vet` the fetched copy |
 | "walk me through vetting this before I install it", "should I install this" | `--vet-source` -> `--vet-plan <target>` (prints the fetch+isolate commands, you run them) -> `--advise <quarantine-path>` for an INSTALL/CAUTION/DO-NOT-INSTALL call |
 | "is my MCP safe", "check my connected servers", "vet my MCP", "are my MCP servers trusted", "MCP supply chain" | `--vet-mcp` (add `--json` or `--sarif PATH` for machine-readable / CI output) |
 | "what dangerous actions can my agent take", "least privilege", "check my tools", "capability", "blast radius", "deeper check" | `--ask` then `--attest <filled.json>` |


### PR DESCRIPTION
Closes the two CI gaps from the packaging audit (Pulse C-232):

- **gitleaks install is now integrity-verified**: download → `sha256sum --check` against the pinned hash of the v8.27.2 linux_x64 release asset → only then extract. Was: `curl | tar` (version-pinned, integrity-unverified) — the last unpinned execution path in CI.
- **SKILL.md / SECURITY.md / SECURITY_MODEL.md are now markdownlint-ed** (previously whole-file-ignored). Fixing them surfaced two real rendering bugs: unescaped pipes in SKILL.md table code-spans were splitting rows into phantom columns on GitHub/ClawHub. SKILL.md keeps a targeted 2-rule inline disable (formatting-only); CHANGELOG.md stays ignored with a comment explaining why.

Verification: full suite **4966 passed**, ruff clean, `markdownlint-cli@0.44.0` clean with the new (narrower) CI invocation.