### PR TITLE
ci: unblock the v4.0.0 publish — the preflight read SKILL.md's own anti-link warning as a link

### DIFF
--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -370,7 +370,18 @@ jobs:
               echo "::error::SKILL.md links to '${target}' but it is not in the staged tree"
               MISSING=1
             fi
-          done < <(grep -oE '\]\([^)]+\)' dist/clawseccheck/SKILL.md | sed -E 's/^\]\(//; s/\)$//')
+          # Strip fenced blocks and inline code spans BEFORE extracting links — the same
+          # two removals tests/test_publish_workflow.py's _prose_only() makes, and for the
+          # same reason it was added there (B-606): SKILL.md has to SHOW the forbidden
+          # `[report.pdf](path)` syntax in order to warn against it, and a naive extractor
+          # reads that illustration as a dangling link. The Python side learned this; this
+          # block did not, because the drift test compared only the four NORMALISATION
+          # rules and never what the two sides EXTRACT. It compares both now.
+          done < <(
+            awk 'BEGIN{fence=0} /^[[:space:]]*```/{fence=!fence; next} !fence' \
+                dist/clawseccheck/SKILL.md \
+              | sed -E 's/`[^`]*`//g' \
+              | grep -oE '\]\([^)]+\)' | sed -E 's/^\]\(//; s/\)$//')
           [ "$MISSING" -eq 0 ] || exit 1
           echo "Preflight OK — SKILL.md present and every relative link resolves."
 

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -712,6 +712,13 @@ def test_preflight_shell_agrees_with_python_normaliser(tmp_path) -> None:
         ("[g](http://example.com/x)", None),
         ("[h](mailto:someone@example.com)", None),
         ("[i](#local-anchor)", None),
+        # EXTRACTION, not normalisation. These are why the comparison exists at all now:
+        # the two sides agreed on all four normalisation rules and still disagreed about
+        # what counts as a link, because only the Python side stripped code (B-606). The
+        # shell published nothing for weeks and then blocked a release on the sentence
+        # SKILL.md uses to warn against exactly this syntax.
+        ("`[j](nope/in-code-span.md)`", None),
+        ("```\n[k](nope/in-fence.md)\n```", None),
     ]
 
     staged_root = tmp_path / "dist" / "clawseccheck"
@@ -732,8 +739,10 @@ def test_preflight_shell_agrees_with_python_normaliser(tmp_path) -> None:
     shell_targets = re.findall(r"::error::SKILL\.md links to '([^']*)'", proc.stdout)
     python_targets = []
     for markdown, _ in cases:
-        raw = _MD_LINK_RE.search(markdown).group(1)
-        target = _normalise_link_target(raw)
+        match = _MD_LINK_RE.search(_prose_only(markdown))
+        if match is None:
+            continue          # code span or fence — not a link on either side
+        target = _normalise_link_target(match.group(1))
         if target is not None:
             python_targets.append(target)
 


### PR DESCRIPTION
One commit. Unblocks the v4.0.0 publish, which failed **before uploading anything**:

```
::error::SKILL.md links to 'path' but it is not in the staged tree
```

There is no such link. `SKILL.md:525` warns the agent never to present the report path as a
link, and to be understood it has to SHOW the syntax it forbids — `` `[report.pdf](path)` ``,
inside a code span. The preflight extracted links with a bare `grep -oE '\]\([^)]+\)'` over the
raw file and read the illustration as a dangling link.

## Why it drifted

The same defect was found and fixed once already, on the other side: B-606 added
`_prose_only()` to `tests/test_publish_workflow.py` — strip fences and code spans before
extracting — with a guard test built on this very example. The shell twin never got it.

What let them drift is the shape of the comparison, not its absence. The workflow's own
comment claims the two resolvers "cannot drift apart again" because a test executes this block
and diffs its output. That test compared the four **normalisation** rules and never what the
two sides **extract**. They agreed on every rule they were compared on, and disagreed on the
question nobody asked.

Both halves are fixed: the preflight strips fences and code spans before extracting, and the
drift test gains two extraction cases (a link in a code span, one in a fence) with the Python
side taken through `_prose_only` too — so the comparison now covers the half that drifted.

## Verification

- Mutation-proven: with the shell fix reverted (and the mutation confirmed present in the file
  before the run), the test fails naming exactly the two targets the shell over-extracts.
- Against the real `SKILL.md`, the fixed pipeline finds 6 links, `path` is not among them, and
  all 6 resolve inside the staged tree.
- CI green on `85b2146`.

## Nothing shipped changes

The staging step is named "Stage publishable files (exclude tests/ + fixtures/)" and copies
neither `tests/` nor `.github/`. The artifact built from this commit is byte-identical to the
one the `v4.0.0` tag's commit would have produced, so the tag still marks the released content
and no new tag is needed — the publish workflow takes its version from `SKILL.md` frontmatter
and can be re-run via `workflow_dispatch`.

Unrelated and already filed: the CI run on the tag showed one macOS-only failure,
`test_b314_check_perf.py::...test_exhaustive_widens_the_cumulative_budget...`, a timing race in
the test itself — the same commit passed the identical job on `main` ten minutes earlier.
